### PR TITLE
Daemon message bug fix

### DIFF
--- a/common/connection.cpp
+++ b/common/connection.cpp
@@ -62,7 +62,12 @@ auto Connection::accept_conn() -> std::expected<int32_t, std::error_code> {
 }
 
 auto Connection::send_msg(std::string msg) -> std::optional<std::error_code> {
-    if (send(socket_fd, &msg, msg.size(), 0) == -1) {
+    constexpr int BUFF_SIZE = 1024;
+    char buff[BUFF_SIZE];
+    strcpy(buff, msg.c_str());
+    
+    int res = send(socket_fd, buff, msg.size() + 1, 0);
+    if (res == -1) {
         return std::make_optional(std::error_code(errno, std::generic_category()));
     }
     return std::nullopt;

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -5,10 +5,11 @@
 
 void handle_client(int client) {
     constexpr int BUFF_SIZE = 1024;
-    char buff[BUFF_SIZE] = {0};
+    char buff[BUFF_SIZE];
     while (true) {
-        memset(&buff, 0, BUFF_SIZE);
-        ssize_t bytes_read = read(client, &buff, BUFF_SIZE - 1);
+        memset(buff, 0, BUFF_SIZE);
+        ssize_t bytes_read = read(client, buff, BUFF_SIZE);
+	std::println("[DBG]: Number of bytes read = {}", bytes_read);
         if (bytes_read <= 0) {
             if (bytes_read == 0) {
                 std::println("[INFO]: Client '{}' disconnected!", client);


### PR DESCRIPTION
The method `send_msg` from `common/connection.cpp` now converts the parameter into a char array before sending it to the daemon.