### PR TITLE
fix: format header files

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -23,6 +23,11 @@ pub fn build(b: *std.Build) void {
     // build_docs(b, target, optimize);
 }
 
+const repl_files = .{
+    "repl/main.cpp",
+    "common/connection.cpp",
+};
+
 fn build_repl(
     b: *std.Build,
     target: ResolvedTarget,
@@ -37,12 +42,8 @@ fn build_repl(
 
     exe.linkLibCpp();
 
-    const repl_files = .{
-        "main.cpp",
-        "../common/connection.cpp",
-    };
     exe.addCSourceFiles(.{
-        .root = b.path("repl"),
+        .root = b.path("."),
         .files = &(repl_files),
         .flags = &CXX_FLAGS,
     });
@@ -59,6 +60,11 @@ fn build_repl(
     run_step.dependOn(&run_cmd.step);
 }
 
+const daemon_files = .{
+    "daemon/main.cpp",
+    "common/connection.cpp",
+};
+
 fn build_daemon(
     b: *std.Build,
     target: ResolvedTarget,
@@ -73,12 +79,8 @@ fn build_daemon(
 
     exe.linkLibCpp();
 
-    const daemon_files = .{
-        "main.cpp",
-        "../common/connection.cpp",
-    };
     exe.addCSourceFiles(.{
-        .root = b.path("daemon"),
+        .root = b.path("."),
         .files = &daemon_files,
         .flags = &CXX_FLAGS,
     });
@@ -95,6 +97,10 @@ fn build_daemon(
     run_step.dependOn(&run_cmd.step);
 }
 
+const test_files = .{
+    "tests/main.cpp",
+};
+
 fn build_tests(
     b: *std.Build,
     target: ResolvedTarget,
@@ -109,11 +115,8 @@ fn build_tests(
 
     unit_tests.linkLibCpp();
 
-    const test_files = .{
-        "main.cpp",
-    };
     unit_tests.addCSourceFiles(.{
-        .root = b.path("tests"),
+        .root = b.path("."),
         .files = &test_files,
         .flags = &CXX_FLAGS,
     });
@@ -141,17 +144,14 @@ fn build_docs(
     // https://ziglang.org/learn/build-system/#system-tools
 }
 
+const header_files = .{
+    "common/include/connection.h",
+    "common/include/database.h",
+    "common/include/object.h",
+};
+
 fn format_code(b: *std.Build, check: bool) void {
-    const files = .{
-        "daemon/main.cpp",
-
-        "repl/main.cpp",
-
-        "common/connection.cpp",
-        "common/include/connection.h",
-
-        "tests/main.cpp",
-    };
+    const files = daemon_files ++ repl_files ++ test_files ++ header_files;
 
     if (!check) {
         const flags = .{"-i"};

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1,19 +1,13 @@
-#include <string>
 #include "include/database.h"
+
+#include <string>
+
 #include "include/object.h"
 
-Database::Database(){
-    content={};
-}
+Database::Database() { content = {}; }
 
-void Database::insert(std::string key, Object value){
-     content[key]=value;
-}
+void Database::insert(std::string key, Object value) { content[key] = value; }
 
-Object Database::get(std::string key){
-      return content[key];
-}
+Object Database::get(std::string key) { return content[key]; }
 
-void Database::remove(std::string key){
-     content.erase(key);
-}
+void Database::remove(std::string key) { content.erase(key); }

--- a/common/include/database.h
+++ b/common/include/database.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include "object.h"
 #include <map>
 #include <string>
 
-class Database{
-    std::map<std::string, Object> content;
+#include "object.h"
 
-public:
+class Database {
+    std::map<std::string, Object> content;
+    Database();
+
+   public:
     void insert(std::string key, Object value);
     Object get(std::string key);
-    void remove(std::string key); 
+    void remove(std::string key);
 };

--- a/common/include/object.h
+++ b/common/include/object.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include<variant>
-#include<string>
-#include<optional>
+#include <optional>
+#include <string>
+#include <variant>
 
-class Object{
-    //for mow, we support ints and strings as values
-    //TODO: add support for fancier types, such as JSON
+class Object {
+    // for mow, we support ints and strings as values
+    // TODO: add support for fancier types, such as JSON
     std::variant<int, std::string> data;
 
-public:
+   public:
     Object(int integer_data);
     Object(const std::string &str_data);
     std::optional<int> asInt() const;

--- a/common/object.cpp
+++ b/common/object.cpp
@@ -1,22 +1,23 @@
-#include<variant>
-#include<string>
-#include<optional>
 #include "include/object.h"
 
-Object::Object(int integer_data): data(integer_data) {}
+#include <optional>
+#include <string>
+#include <variant>
 
-Object::Object(const std::string &string_data): data(string_data){}
+Object::Object(int integer_data) : data(integer_data) {}
 
-std::optional<int> Object::asInt() const{
-     if(auto ptr=std::get_if<int>(&data)){
+Object::Object(const std::string &string_data) : data(string_data) {}
+
+std::optional<int> Object::asInt() const {
+    if (auto ptr = std::get_if<int>(&data)) {
         return *ptr;
-     }
-     return std::nullopt;
+    }
+    return std::nullopt;
 }
 
-std::optional<std::string> Object::asString() const{
-     if(auto ptr=std::get_if<std::string>(&data)){
+std::optional<std::string> Object::asString() const {
+    if (auto ptr = std::get_if<std::string>(&data)) {
         return *ptr;
-     }
-     return std::nullopt;
+    }
+    return std::nullopt;
 }

--- a/repl/main.cpp
+++ b/repl/main.cpp
@@ -1,8 +1,7 @@
 #include <iostream>
 
 #include "../common/include/connection.h"
-#include "../common/include/database.h"
-#include "../common/include/object.h"
+
 int main() {
     constexpr int32_t PORT = 8080;
     Connection conn = Connection(PORT);


### PR DESCRIPTION
Previously header files were ignored by `zig build format` as there weren't needed for actually building the binaris.