### PR TITLE
Added MULTI functionality to repl

### DIFF
--- a/repl/main.cpp
+++ b/repl/main.cpp
@@ -1,7 +1,9 @@
 #include <chrono>
 #include <iostream>
 #include <print>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include "../common/include/connection.h"
 
@@ -19,6 +21,9 @@ int main() {
     constexpr auto TIMEOUT_DURATION = std::chrono::minutes(10);
 
     bool running = true;
+    bool buffering = false;
+    std::vector<std::string> command_buffer;
+
     while (running) {
         if (failed_commands == ALLOWED_FAILS) {
             std::println(std::cerr,
@@ -28,7 +33,7 @@ int main() {
         }
 
         std::string command;
-        std::print("> ");
+        std::print("{}", buffering ? "(MULTI)> " : "> ");
         auto start = std::chrono::steady_clock::now();
 
         while (!std::cin.rdbuf()->in_avail()) {
@@ -42,7 +47,49 @@ int main() {
         }
 
         std::getline(std::cin, command);
-        std::println(std::cerr, "[DBG]: Command send = '{}'", command);
+        std::println(std::cerr, "[DBG]: Command received = '{}'", command);
+
+        if (command == "MULTI") {
+            if (buffering) {
+                std::println(std::cerr, "[WARN]: Already in MULTI mode. Ignoring duplicate MULTI.");
+                continue;
+            }
+            buffering = true;
+            command_buffer.clear();
+            std::println("Entering MULTI mode. Type EXEC to send commands.");
+            continue;
+        }
+
+        if (command == "EXEC") {
+            if (!buffering) {
+                std::println(std::cerr, "[WARN]: EXEC called outside of MULTI mode. Ignoring.");
+                continue;
+            }
+
+            std::string joined;
+            for (const auto& cmd : command_buffer) {
+                joined += cmd + '\n';
+            }
+
+            auto res = conn.send_msg(joined);
+            if (res != std::nullopt) {
+                failed_commands++;
+                std::println(std::cerr, "{}", res.value().message());
+            } else {
+                std::println("All MULTI commands sent!");
+                failed_commands = 0;
+            }
+
+            buffering = false;
+            command_buffer.clear();
+            continue;
+        }
+
+        if (buffering) {
+            command_buffer.push_back(command);
+            std::println("[INFO]: Command added to MULTI buffer.");
+            continue;
+        }
 
         auto res = conn.send_msg(command);
         if (res != std::nullopt) {


### PR DESCRIPTION
You can now send multiple commands at once using the MULTI and EXEC keywords before and after the set of commands